### PR TITLE
feat(pipeline): change parallel input argument to be false by default

### DIFF
--- a/src/yarea/pipeline.py
+++ b/src/yarea/pipeline.py
@@ -27,8 +27,8 @@ def parser():
                         help="List of negative control types to run feature extraction on. Input as comma-separated list with no spaces.  \
                               Options: randomized_full,randomized_roi,randomized_non_roi,shuffled_full,shuffled_roi,shuffled_non_roi")
 
-    parser.add_argument("--parallel", action="store_false",
-                        help="Whether to run feature extraction in a parallel process. True by default.")
+    parser.add_argument("--parallel", action="store_true",
+                        help="Whether to run feature extraction in a parallel process. False by default.")
 
     parser.add_argument("--update", action="store_true", help="Flag to force rerun all steps of pipeline. False by default.")
 


### PR DESCRIPTION
Parallelization is turned off by default as it is causing issues in debugging. Will likely switch back to being on by default once test runs on large datasets are completed.